### PR TITLE
docs: Update pve-configure → pve-setup scenario name

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,10 +6,10 @@ Ansible playbooks for configuring fresh Proxmox VE installations and installing 
 
 ```bash
 # Post-install configuration (local via iac-driver)
-cd ../iac-driver && ./run.sh --scenario pve-configure --local
+cd ../iac-driver && ./run.sh --scenario pve-setup --local
 
 # Post-install configuration (remote via iac-driver)
-cd ../iac-driver && ./run.sh --scenario pve-configure --remote <IP>
+cd ../iac-driver && ./run.sh --scenario pve-setup --remote <IP>
 
 # Or run playbooks directly:
 ansible-playbook -i inventory/local.yml playbooks/pve-setup.yml


### PR DESCRIPTION
## Summary

Update documentation to reflect iac-driver scenario rename from `pve-configure` to `pve-setup` (iac-driver#57).

## Changes
- `CLAUDE.md`: Update quick reference examples

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)