### PR TITLE
fix(base): Use packages variable from ConfigResolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- Fix base role to use `packages` variable from ConfigResolver
+  - Changed from `common_packages` to `packages` variable name
+  - Added conditional to skip when packages list is empty
+  - Aligns with site-config resolved ansible vars
+
 ## v0.28 - 2026-01-18
 
 ### Features

--- a/collections/ansible_collections/homestak/debian/roles/base/tasks/main.yml
+++ b/collections/ansible_collections/homestak/debian/roles/base/tasks/main.yml
@@ -12,8 +12,9 @@
 
 - name: Install common packages
   ansible.builtin.apt:
-    name: "{{ common_packages }}"
+    name: "{{ packages | default([]) }}"
     state: present
+  when: packages is defined and packages | length > 0
 
 - name: Install extra packages for environment
   ansible.builtin.apt:


### PR DESCRIPTION
## Summary

Align base role with ConfigResolver's resolved ansible vars output.

## Type of Change
- [x] Bug fix

## Changes

- Changed `common_packages` to `packages` variable name
- Added conditional to skip when packages list is empty or undefined
- Aligns with site-config resolved ansible vars from iac-driver ConfigResolver

## Testing

Validated via iac-driver recursive-pve-roundtrip and nested-pve-roundtrip scenarios.

## PR Readiness Checklist

- [x] Feature tested end-to-end
- [x] CHANGELOG entry in this PR